### PR TITLE
Bug fixes for DTGuild/ DTLinks tooltips

### DIFF
--- a/XFaction/Core/DataText/DTGuild.lua
+++ b/XFaction/Core/DataText/DTGuild.lua
@@ -397,10 +397,8 @@ function DTGuild:OnLeave()
 	if _Tooltip and MouseIsOver(_Tooltip) then
 	    return
 	else
-	    if XFG.Lib.QT:IsAcquired(ObjectName) then _Tooltip:Clear() end
-	        _Tooltip:Hide()
-		XFG.Lib.QT:Release(ObjectName)
-		_Tooltip = nil
+        XFG.Lib.QT:Release(_Tooltip)
+        _Tooltip = nil
 	end
 end
 

--- a/XFaction/Core/DataText/DTLinks.lua
+++ b/XFaction/Core/DataText/DTLinks.lua
@@ -163,9 +163,7 @@ function DTLinks:OnLeave()
 	if _Tooltip and MouseIsOver(_Tooltip) then
         return
     else
-		if XFG.Lib.QT:IsAcquired(ObjectName) then _Tooltip:Clear() end
-		_Tooltip:Hide()
-		XFG.Lib.QT:Release(ObjectName)
-		_Tooltip = nil
+        XFG.Lib.QT:Release(_Tooltip)
+        _Tooltip = nil
 	end
 end


### PR DESCRIPTION
I am unable to repro #166 however I compared to another addon ([WarfrontRareTracker](https://github.com/StevenSeegal/WarfrontRareTracker/blob/b3a84c49a855c145d7a5f6f0b091ea9eb77a4309/WarfrontRareTracker.lua#L2819))  and noticed that currently ObjectName (String) is being passed to QT:Release which expects the tooltip. Im hoping this change is what is needed for those impacted. 