### PR TITLE
LFG Prototype

### DIFF
--- a/XFaction/Constants.lua
+++ b/XFaction/Constants.lua
@@ -25,6 +25,9 @@ XFG.Icons = {
 	Alliance = 2565243,
 	Horde = 463451,
 	Gold = [[|TInterface\MONEYFRAME\UI-GoldIcon:16:16|t]],
+    DPS = '|TInterface\\LFGFrame\\UI-LFG-ICON-PORTRAITROLES.blp:16:16:0:%d:64:64:20:39:22:41|t',
+    Healer = '|TInterface\\LFGFrame\\UI-LFG-ICON-PORTRAITROLES.blp:16:16:0:%d:64:64:20:39:1:20|t',
+    Tank = '|TInterface\\LFGFrame\\UI-LFG-ICON-PORTRAITROLES.blp:16:16:0:%d:64:64:0:19:22:41|t',
 }
 
 XFG.Lib = {

--- a/XFaction/Core/Configuration/DataText.lua
+++ b/XFaction/Core/Configuration/DataText.lua
@@ -161,7 +161,8 @@ XFG.Options.args.DataText = {
 						Achievement = XFG.Lib.Locale['ACHIEVEMENT'],
 						Guild = XFG.Lib.Locale['GUILD'],
 						ItemLevel = XFG.Lib.Locale['ITEMLEVEL'],
-						Level = XFG.Lib.Locale['LEVEL'],            
+						Level = XFG.Lib.Locale['LEVEL'],
+						LFG = XFG.Lib.Locale['LFG'],
 						Dungeon = XFG.Lib.Locale['DUNGEON'],
                         Name = XFG.Lib.Locale['NAME'],
 						Note = XFG.Lib.Locale['NOTE'],
@@ -193,6 +194,7 @@ XFG.Options.args.DataText = {
 						Guild = XFG.Lib.Locale['GUILD'],
 						ItemLevel = XFG.Lib.Locale['ITEMLEVEL'],
 						Level = XFG.Lib.Locale['LEVEL'],
+						LFG = XFG.Lib.Locale['LFG'],       
 						Dungeon = XFG.Lib.Locale['DUNGEON'],
 						Name = XFG.Lib.Locale['NAME'],
 						Note = XFG.Lib.Locale['NOTE'],
@@ -436,6 +438,44 @@ XFG.Options.args.DataText = {
 					disabled = function () return (not XFG.Config.DataText.Guild.Enable.Level) end,
 					name = XFG.Lib.Locale['ALIGNMENT'],
 					desc = XFG.Lib.Locale['DTGUILD_CONFIG_COLUMN_LEVEL_ALIGNMENT_TOOLTIP'],
+					values = {
+						Center = XFG.Lib.Locale['CENTER'],
+						Left = XFG.Lib.Locale['LEFT'],
+						Right = XFG.Lib.Locale['RIGHT'],
+                    },
+					get = function(info) return XFG.Config.DataText.Guild.Alignment[ info[#info] ] end,
+					set = function(info, value) XFG.Config.DataText.Guild.Alignment[ info[#info] ] = value; end
+				},
+				LFG = {
+					order = 17,
+					type = 'toggle',
+					hidden = function () return XFG.Config.DataText.Guild.Column ~= 'LFG' end,
+					name = XFG.Lib.Locale['ENABLE'],
+					desc = XFG.Lib.Locale['DTGUILD_CONFIG_COLUMN_LFG_TOOLTIP'],
+					get = function(info) return XFG.Config.DataText.Guild.Enable[ info[#info] ] end,
+					set = function(info, value) 
+						XFG.Config.DataText.Guild.Enable[ info[#info] ] = value
+						if(value) then AddedMenuItem(info[#info]) else RemovedMenuItem(info[#info]) end
+					end
+				},
+				LFGOrder = {
+					order = 18,
+					type = 'select',
+					hidden = function () return XFG.Config.DataText.Guild.Column ~= 'LFG' end,
+					disabled = function () return (not XFG.Config.DataText.Guild.Enable.LFG) end,
+					name = XFG.Lib.Locale['ORDER'],
+					desc = XFG.Lib.Locale['DTGUILD_CONFIG_COLUMN_LFG_ORDER_TOOLTIP'],
+					values = function () return OrderMenu() end,
+					get = function(info) if(XFG.Config.DataText.Guild.Enable.LFG) then return tostring(XFG.Config.DataText.Guild.Order[ info[#info] ]) end end,
+					set = function(info, value) SelectedMenuItem(info[#info], value) end
+				},
+				LFGAlignment = {
+					order = 19,
+					type = 'select',
+					hidden = function () return XFG.Config.DataText.Guild.Column ~= 'LFG' end,
+					disabled = function () return (not XFG.Config.DataText.Guild.Enable.LFG) end,
+					name = XFG.Lib.Locale['ALIGNMENT'],
+					desc = XFG.Lib.Locale['DTGUILD_CONFIG_COLUMN_LFG_ALIGNMENT_TOOLTIP'],
 					values = {
 						Center = XFG.Lib.Locale['CENTER'],
 						Left = XFG.Lib.Locale['LEFT'],

--- a/XFaction/Core/Configuration/Defaults.lua
+++ b/XFaction/Core/Configuration/Defaults.lua
@@ -77,6 +77,7 @@ XFG.Defaults = {
                     Faction = true,
                     Guild = true,
                     Level = true,
+                    LFG = false,
                     Name = true,
                     Note = false,
                     Profession = true,
@@ -99,6 +100,7 @@ XFG.Defaults = {
                     GuildOrder = 7,
                     ItemLevelOrder = 0,
                     LevelOrder = 2,
+                    LFGOrder = 0,
                     NameOrder = 4,
                     NoteOrder = 0,
                     ProfessionOrder = 12,
@@ -119,6 +121,7 @@ XFG.Defaults = {
                     GuildAlignment = 'Left',
                     ItemLevelAlignment = 'Center',
                     LevelAlignment = 'Center',
+                    LFGAlignment = 'Center',
                     DungeonAlignment = 'Center',
                     NameAlignment = 'Left',
                     NoteAlignment = 'Left',
@@ -139,8 +142,24 @@ XFG.Defaults = {
             Link = {
                 Label = false,
                 Faction = true
+            }
+        },
+        LFG = {
+            Role = {
+                Tank = false,
+                Healer = false,
+                DPS = false
             },
-        }
+            Activity = {
+                RA = false,
+                RH = false,
+                RM = false,
+                SM = false,
+                SP = false,
+                SS = false,
+                TW = false
+            },
+        },
     }
 }
     
@@ -155,6 +174,7 @@ function XFG:LoadConfigs()
     XFG.Lib.ConfigDialog:AddToBlizOptions(XFG.Category, 'Channel', XFG.Category, 'Channel')
     XFG.Lib.ConfigDialog:AddToBlizOptions(XFG.Category, 'Chat', XFG.Category, 'Chat')
     XFG.Lib.ConfigDialog:AddToBlizOptions(XFG.Category, 'DataText', XFG.Category, 'DataText')
+    XFG.Lib.ConfigDialog:AddToBlizOptions(XFG.Category, 'LFG', XFG.Category, 'LFG')
     XFG.Lib.ConfigDialog:AddToBlizOptions(XFG.Category, 'Support', XFG.Category, 'Support')
     XFG.Lib.ConfigDialog:AddToBlizOptions(XFG.Category, 'Debug', XFG.Category, 'Debug')
     XFG.Lib.ConfigDialog:AddToBlizOptions(XFG.Category, 'Profile', XFG.Category, 'Profile')

--- a/XFaction/Core/Configuration/LFG.lua
+++ b/XFaction/Core/Configuration/LFG.lua
@@ -1,0 +1,51 @@
+local XFG, G = unpack(select(2, ...))
+local LogCategory = 'Config'
+
+XFG.Options.args.LFG = {
+	name = XFG.Lib.Locale['LFG'],
+	order = 1,
+	type = 'group',
+	args = {
+		LFG = {
+			order = 1,
+			type = 'group',
+			name = XFG.Lib.Locale['LFG'],
+			guiInline = true,
+			args = {
+				Role = {
+					type = "multiselect",
+					order = 1,
+					name = XFG.Lib.Locale['LFG_ROLE'],
+					values = {
+						Tank = XFG.Icons.Tank,
+						Healer = XFG.Icons.Healer,
+						DPS = XFG.Icons.DPS
+                    },
+					get = function(info, k) return XFG.Config.LFG.Role[k] end,
+					set = function(info, k, v)                      
+						XFG.Config.LFG.Role[k] = v
+					end,
+				},
+				Activity = {
+					type = "multiselect",
+					order = 2,
+					name = XFG.Lib.Locale['LFG_ACTIVITY'],
+					values = {
+                    --Ace spits out order based on property name descending, these are in desired order
+						RA = XFG.Lib.Locale['LFG_RAID_NORMAL'],
+						RH = XFG.Lib.Locale['LFG_RAID_HEROIC'],
+						RM = XFG.Lib.Locale['LFG_RAID_MYTHIC'],
+						SM = XFG.Lib.Locale['LFG_MYTHIC_PLUS'], 
+                        SP = XFG.Lib.Locale['LFG_PVP'],
+						SS = XFG.Lib.Locale['LFG_SOCIAL'],
+						TW = XFG.Lib.Locale['LFG_TIMEWALKING'],
+                    },
+					get = function(info, k) return XFG.Config.LFG.Activity[k] end,
+					set = function(info, k, v)
+						XFG.Config.LFG.Activity[k] = v
+					end,
+				},
+			}
+		}
+	}
+}

--- a/XFaction/Core/Configuration/Load_Configurations.xml
+++ b/XFaction/Core/Configuration/Load_Configurations.xml
@@ -4,6 +4,7 @@
     <Script file='Channel.lua'/>
     <Script file='Chat.lua'/>
     <Script file='DataText.lua'/>    
+    <Script file='LFG.lua'/>
     <Script file='Support.lua'/>
     <Script file='Debug.lua'/>
 </Ui>

--- a/XFaction/Core/DataText/DTGuild.lua
+++ b/XFaction/Core/DataText/DTGuild.lua
@@ -104,6 +104,7 @@ local function PreSort()
 		_UnitData.ItemLevel = _Unit:GetItemLevel()
 		_UnitData.Raid = _Unit:GetRaidProgress()
 		_UnitData.PvP = _Unit:GetPvP()
+		_UnitData.LFG = _Unit:GetLFG()
 
 		if(_Unit:HasVersion()) then
 			_UnitData.Version = _Unit:GetVersion()
@@ -176,6 +177,19 @@ local function LineClick(_, inUnitGUID, inMouseButton)
  	else
 		SetItemRef(_Link, _Unit:GetName(), inMouseButton)
 	end
+end
+
+local function MenuTooltipOnCellEnter(self, info)
+    local _tooltipContainsHyperLink = false
+    local _preString, _hyperLinkString, _postString
+    _tooltipContainsHyperLink, _preString, _hyperLinkString, _postString = ExtractHyperlinkString(info)
+    if (_tooltipContainsHyperLink) then
+        GameTooltip_SetDefaultAnchor(GameTooltip, UIParent)
+        GameTooltip:SetHyperlink(_hyperLinkString)
+        GameTooltip:Show()
+    else
+        GameTooltip:Hide()
+    end
 end
 
 function DTGuild:RefreshBroker()
@@ -313,10 +327,17 @@ function DTGuild:OnEnter(this)
 				elseif(_ColumnName == 'Name') then
 					local _ClassHexColor = _UnitData.Class:GenerateHexColor()
 					_CellValue = format('|c%s%s|r', _ClassHexColor, _UnitData.Name)
-				elseif(_UnitData[_ColumnName] ~= nil) then
+                elseif(_UnitData[_ColumnName] ~= nil) then
 					_CellValue = format('|cffffffff%s|r', _UnitData[_ColumnName])
 				end
 				_Tooltip:SetCell(line, i, _CellValue)
+                
+                -- Cell must be set before assigning script
+                if(_ColumnName == 'LFG') then
+                    if(_UnitData[_ColumnName] ~= nil) then
+                        _Tooltip:SetCellScript(line, i, 'OnEnter', MenuTooltipOnCellEnter, _UnitData[_ColumnName])
+                    end
+				end
 			end
 
 	 		_Tooltip:SetLineScript(line, "OnMouseUp", LineClick, _UnitData.GUID)

--- a/XFaction/Core/Handlers/TimerEvent.lua
+++ b/XFaction/Core/Handlers/TimerEvent.lua
@@ -320,6 +320,7 @@ end
 function TimerEvent:CallbackHeartbeat()
     if(XFG.Initialized and XFG.Player.LastBroadcast < GetServerTime() - XFG.Settings.Player.Heartbeat) then
         XFG:Debug(LogCategory, "Sending heartbeat")
+        XFG.Player.Unit:Initialize(XFG.Player.Unit:GetID())
         XFG.Outbox:BroadcastUnitData(XFG.Player.Unit, XFG.Settings.Network.Message.Subject.DATA)
     end
     local _Timer = XFG.Timers:GetTimer('Heartbeat')

--- a/XFaction/Core/Locales/enUS.lua
+++ b/XFaction/Core/Locales/enUS.lua
@@ -165,6 +165,9 @@ L['DTGUILD_CONFIG_COLUMN_GUILD_ALIGNMENT_TOOLTIP'] = 'Guild name text justificat
 L['DTGUILD_CONFIG_COLUMN_ITEMLEVEL_TOOLTIP'] = 'Show player max item level'
 L['DTGUILD_CONFIG_COLUMN_ITEMLEVEL_ORDER_TOOLTIP'] = 'Column number the max item level will be displayed in'
 L['DTGUILD_CONFIG_COLUMN_ITEMLEVEL_ALIGNMENT_TOOLTIP'] = 'Item level text justification'
+L['DTGUILD_CONFIG_COLUMN_LFG_TOOLTIP'] = 'Show player LFG'
+L['DTGUILD_CONFIG_COLUMN_LFG_ORDER_TOOLTIP'] = 'Column number LFG will be displayed in'
+L['DTGUILD_CONFIG_COLUMN_LFG_ALIGNMENT_TOOLTIP'] = 'LFG text justification'
 L['DTGUILD_CONFIG_COLUMN_LEVEL_TOOLTIP'] = 'Show player level'
 L['DTGUILD_CONFIG_COLUMN_LEVEL_ORDER_TOOLTIP'] = 'Column number the players level will be displayed in'
 L['DTGUILD_CONFIG_COLUMN_LEVEL_ALIGNMENT_TOOLTIP'] = 'Player level text justification'
@@ -206,6 +209,19 @@ L['DTGUILD_CONFIG_COLUMN_ZONE_ORDER_TOOLTIP'] = 'Column number the player zone w
 L['DTGUILD_CONFIG_COLUMN_ZONE_ALIGNMENT_TOOLTIP'] = 'Player zone text justification'
 L['DTGUILD_CONFIG_SORT_TOOLTIP'] = 'Select the default sort column'
 L['DTGUILD_CONFIG_SIZE_TOOLTIP'] = 'Select the maximum height of the window before it starts scrolling'
+--=========================================================================
+-- LFG Specific
+--=========================================================================
+L['LFG'] = 'LFG'
+L['LFG_ROLE'] = 'Looking for group as'
+L['LFG_ACTIVITY'] = 'Looking for group activities'
+L['LFG_RAID_NORMAL'] = 'Raid Normal'
+L['LFG_RAID_HEROIC'] = 'Raid Heroic'
+L['LFG_RAID_MYTHIC'] = 'Raid Mythic'
+L['LFG_MYTHIC_PLUS'] = 'Mythic+'
+L['LFG_TIMEWALKING'] = 'Timewalking'
+L['LFG_PVP'] = 'PvP'
+L['LFG_SOCIAL'] = 'Social'
 -------------------------
 -- DTLinks (X)
 -------------------------

--- a/XFaction/Core/Network/Decode.lua
+++ b/XFaction/Core/Network/Decode.lua
@@ -85,6 +85,7 @@ function XFG:DeserializeUnitData(inData)
 	end
 	_UnitData:SetZone(_DeserializedData.Z)
 
+	if(_DeserializedData.W ~= nil) then _UnitData:SetLFG(_DeserializedData.W) end
 	if(_DeserializedData.B ~= nil) then _UnitData:SetAchievementPoints(_DeserializedData.B) end
 	if(_DeserializedData.Y ~= nil) then _UnitData:SetPvPString(_DeserializedData.Y) end
 	if(_DeserializedData.X ~= nil) then _UnitData:SetVersion(_DeserializedData.X) end

--- a/XFaction/Core/Network/Encode.lua
+++ b/XFaction/Core/Network/Encode.lua
@@ -81,6 +81,7 @@ function XFG:SerializeUnitData(inUnitData)
 		local _Spec = inUnitData:GetSpec()
 		_MessageData.V = _Spec:GetKey()
 	end
+	_MessageData.W = inUnitData:GetLFG()
 	_MessageData.X = inUnitData:GetVersion()
 	_MessageData.Y = inUnitData:GetPvP()
 	_MessageData.Z = inUnitData:GetZone()

--- a/XFaction/Core/Unit/Unit.lua
+++ b/XFaction/Core/Unit/Unit.lua
@@ -44,6 +44,7 @@ function Unit:new()
     self._Realm = nil
     self._Version = nil
     self._ItemLevel = 0
+    self._LFG = ''
     self._RaidProgress = ''
     self._PvP = ''
 
@@ -123,6 +124,11 @@ function Unit:Initialize(inMemberID)
         if(type(_ItemLevel) == 'number') then
             _ItemLevel = math.floor(_ItemLevel)
             self:SetItemLevel(_ItemLevel)
+        end
+        
+        local _LFG = self:GetLFGFromConfig()
+        if(type(_LFG) == 'string') then
+            self:SetLFG(_LFG)
         end
 
         local _CovenantID = C_Covenants.GetActiveCovenantID()
@@ -211,6 +217,7 @@ function Unit:Print()
     XFG:Debug(LogCategory, '  _MainName (' .. type(self._MainName) .. '): ' .. tostring(self._MainName))
     XFG:Debug(LogCategory, '  _IsPlayer (' .. type(self._IsPlayer) .. '): ' .. tostring(self._IsPlayer))
     XFG:Debug(LogCategory, '  _ItemLevel (' .. type(self._ItemLevel) .. '): ' .. tostring(self._ItemLevel))
+    XFG:Debug(LogCategory, '  _LFG (' .. type(self._LFG) .. '): ' .. tostring(self._LFG))
     XFG:Debug(LogCategory, '  _RaidProgress (' .. type(self._RaidProgress) .. '): ' .. tostring(self._RaidProgress))
     XFG:Debug(LogCategory, '  _PvP (' .. type(self._PvP) .. '): ' .. tostring(self._PvP))
     if(self:HasRealm()) then self._Realm:Print() end
@@ -646,6 +653,69 @@ function Unit:SetItemLevel(inItemLevel)
     return self:GetItemLevel()
 end
 
+function Unit:GetLFG()
+    return self._LFG
+end
+
+function Unit:SetLFG(inLFG)
+    assert(type(inLFG) == 'string')
+    self._LFG = inLFG
+    return self:GetLFG()
+end
+
+function Unit:GetLFGFromConfig()
+
+    local _LFG = ''
+    
+    if(XFG.Config.LFG.Role.Tank) then  
+        _LFG = _LFG .. format('%s ', XFG.Icons.Tank)
+    end
+    if(XFG.Config.LFG.Role.Healer) then  
+        _LFG = _LFG .. format('%s ', XFG.Icons.Healer)
+    end
+    if(XFG.Config.LFG.Role.DPS) then  
+        _LFG = _LFG .. format('%s ', XFG.Icons.DPS)
+    end
+
+    if(XFG.Config.LFG.Activity.RA or XFG.Config.LFG.Activity.RH or XFG.Config.LFG.Activity.RM) then  
+        _LFG = _LFG .. 'R'
+        
+        if(XFG.Config.LFG.Activity.RA) then  
+            _LFG = _LFG .. 'N'
+        end
+        if(XFG.Config.LFG.Activity.RH) then  
+            _LFG = _LFG .. 'H'
+        end
+        if(XFG.Config.LFG.Activity.RM) then  
+            _LFG = _LFG .. 'M'
+        end
+        _LFG = _LFG .. ' '
+    end
+    
+    if(XFG.Config.LFG.Activity.SM) then  
+        if C_MythicPlus.GetOwnedKeystoneLevel() ~= nil then
+            _LFG = _LFG .. '|cffa335ee|Hkeystone:180653:' .. C_MythicPlus.GetOwnedKeystoneChallengeMapID() .. ':' .. C_MythicPlus.GetOwnedKeystoneLevel() .. ':0:0:0:0|h[M+]|h|r'
+        else
+            _LFG = _LFG .. 'M+ '
+        end
+    end
+    
+    if(XFG.Config.LFG.Activity.SP) then  
+        _LFG = _LFG .. 'PvP '
+    end
+    
+    if(XFG.Config.LFG.Activity.SS) then  
+        _LFG = _LFG .. 'S '
+    end
+    
+    if(XFG.Config.LFG.Activity.TW) then  
+        _LFG = _LFG .. 'TW '
+    end
+    gsub(_LFG, "%s+", "")
+
+    return _LFG
+end
+
 function Unit:IsSameFaction()
     return XFG.Player.Faction:Equals(self:GetFaction())
 end
@@ -686,6 +756,7 @@ function Unit:Equals(inUnit)
     if(self:GetItemLevel() ~= inUnit:GetItemLevel()) then return false end
     if(self:GetPvP() ~= inUnit:GetPvP()) then return false end
     if(self:GetRaidProgress() ~= inUnit:GetRaidProgress()) then return false end
+    if(self:GetLFG() ~= inUnit:GetLFG()) then return false end
 
     if(self:HasCovenant() == false and inUnit:HasCovenant()) then return false end
     if(self:HasCovenant()) then


### PR DESCRIPTION
Hey, I put this together as a prototype to see if its worth integrating. Its an LFG configuration where you can select the roles and activities you would be open to grouping for and adds it as data in DTGuild. If the user also has Mythic + selected it will share their keystone as well for a hover text. Thought it would be a nice to have for guild members as a way to find others, and for guild admins to see what sorts of activities their guild are wanting to pursue.

Here it is in action, sorry for the horrible UI :( 12+ years being frankensteined 
![LFG](https://user-images.githubusercontent.com/30186117/177489581-be17cea4-02b0-4762-92dc-01637d2f9293.jpg)

